### PR TITLE
Add solution for this 'while' clause does not guard error

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -54,6 +54,16 @@ The [makefile documentation](build.md) describes the build options supported and
 
 * You get `make: *** No targets specified and no makefile found.  Stop.`
   Solution: `cd firmware/main`
+  
+* Newer GCCs produce this error message:
+  ```
+MCU/STM32F2xx/SPARK_Firmware_Driver/src/system_stm32f2xx.c: In function 'SetSysClock':
+MCU/STM32F2xx/SPARK_Firmware_Driver/src/system_stm32f2xx.c:394:5: error: this 'while' clause does not guard... [-Werror=misleading-indentation]
+     while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
+     ^~~~~
+  ```
+  Solution: Add `CFLAGS=-Wno-misleading-indentation` to the make command to disable this warning altogether.
+  Example: `make clean all PLATFORM=photon CFLAGS=-Wno-misleading-indentation program-dfu`
 
 Please issue a pull request if you come across similar issues/fixes that trip you up.
 


### PR DESCRIPTION
I've installed arm-none-eabi-gcc version
```gcc version 6.2.1 20161205 (release) [ARM/embedded-6-branch revision 243739] (GNU Tools for ARM Embedded Processors)```
which causes this error message when building:

```
MCU/STM32F2xx/SPARK_Firmware_Driver/src/system_stm32f2xx.c: In function 'SetSysClock':
MCU/STM32F2xx/SPARK_Firmware_Driver/src/system_stm32f2xx.c:394:5: error: this 'while' clause does not guard... [-Werror=misleading-indentation]
     while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
```

This pull request adds a new solution to the Getting Started page that addresses this issue by disabling this specific type of warning in the compiler options.

This is a doc-only change, therefore I haven't run any tests.
---

Doneness:

- [x] Contributor has signed CLA
- [x] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)